### PR TITLE
For 43 data saved correctly from api

### DIFF
--- a/app/src/main/java/com/jasminsp/weatherapp/App.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/App.kt
@@ -1,0 +1,20 @@
+package com.jasminsp.weatherapp
+
+import android.app.Application
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+
+class App : Application() {
+    private val appScope = CoroutineScope(Dispatchers.Main)
+    companion object {
+        lateinit var appContext: Context
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Log.d("QQQ", "MyApp onCreate")
+        appContext = applicationContext
+    }
+}

--- a/app/src/main/java/com/jasminsp/weatherapp/MainActivity.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/MainActivity.kt
@@ -21,11 +21,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Transformations
+import androidx.lifecycle.viewModelScope
 import com.jasminsp.weatherapp.ui.theme.WeatherAppTheme
 import com.jasminsp.weatherapp.weather.WeatherViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import java.io.Console
 
 class MainActivity : ComponentActivity() {
@@ -42,49 +43,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    GetLocations(weatherViewModel)
-                }
-            }
-        }
-    }
-
-    @Composable
-    fun GetLocations(viewModel: WeatherViewModel) {
-        val searchInput by remember { mutableStateOf("berlin") }
-        viewModel.getLocations(searchInput)
-        ShowSearchResult(viewModel)
-    }
-
-    @Composable
-    fun ShowSearchResult(viewModel: WeatherViewModel) {
-        val searchResult by viewModel.searchedLocations.observeAsState()
-
-        Column(Modifier.fillMaxWidth()) {
-            // Place for search input
-            LazyColumn(Modifier.fillMaxWidth()) {
-                searchResult?.results?.forEach {
-                    item {
-                        Card(
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    onSearchResultClick(viewModel, it.latitude, it.longitude)
-                                }) {
-                            Column(Modifier.padding(all = 20.dp)) {
-                                Row(Modifier.fillMaxWidth().padding(start = 15.dp), Arrangement.SpaceBetween, Alignment.CenterVertically) {
-                                    if (it.admin3 != null) Text(
-                                        it.admin3,
-                                        fontSize = 22.sp
-                                    ) else it.admin2?.let { name -> Text(name, fontSize = 22.sp) }
-                                    Text("Add", Modifier.padding(top = 20.dp), color = Color.Gray)
-                                }
-                                Text(
-                                    "${it.admin1}, ${it.country}",
-                                    Modifier.padding(start = 15.dp),
-                                    fontWeight = FontWeight(400), color = Color.Gray
-                                )
-                            }
-                        }
+                    Column {
+                        ShowFavourites(weatherViewModel)
+                        SearchLocations(weatherViewModel)
                     }
                 }
             }
@@ -92,8 +53,7 @@ class MainActivity : ComponentActivity() {
     }
 }
 
-// Get data of the location clicked
-private fun onSearchResultClick(viewModel: WeatherViewModel, lat: Double, long: Double) {
-    viewModel.getFavouriteWeather(lat, long)
-    viewModel.addFavourite(lat, long)
+// Save new favourite to db
+fun addFavourite(viewModel: WeatherViewModel, lat: Double, long: Double) {
+        viewModel.addFavourite(lat, long)
 }

--- a/app/src/main/java/com/jasminsp/weatherapp/MainActivity.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/MainActivity.kt
@@ -1,21 +1,26 @@
 package com.jasminsp.weatherapp
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.MutableLiveData
 import com.jasminsp.weatherapp.ui.theme.WeatherAppTheme
 import com.jasminsp.weatherapp.weather.WeatherViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.io.Console
 
 class MainActivity : ComponentActivity() {
     companion object {
@@ -31,10 +36,39 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    weatherViewModel.getLocations("Berlin")
-                    //weatherViewModel.getFavouriteWeather(52.52437, 13.41053)
+                    GetLocations(weatherViewModel)
                 }
             }
         }
     }
+
+    @Composable
+    fun GetLocations(viewModel: WeatherViewModel) {
+        val searchInput by remember { mutableStateOf("berlin") }
+        viewModel.getLocations(searchInput)
+        ShowSearchResult(viewModel)
+    }
+
+    @Composable
+    fun ShowSearchResult(viewModel: WeatherViewModel) {
+        val searchResult by viewModel.searchedLocations.observeAsState()
+
+        LazyColumn {
+            searchResult?.results?.forEach {
+                item {
+                    Card(Modifier.clickable {
+                        onSearchResultClick(viewModel, it.latitude, it.longitude)
+                    }) {
+                        it.country?.let { name -> Text(name) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Get data of the location clicked
+private fun onSearchResultClick(viewModel: WeatherViewModel, lat: Double, long: Double) {
+    viewModel.getFavouriteWeather(lat, long)
+    viewModel.addFavourite(lat, long)
 }

--- a/app/src/main/java/com/jasminsp/weatherapp/MainActivity.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/MainActivity.kt
@@ -13,14 +13,11 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import com.jasminsp.weatherapp.sensor.SensorViewModel
 import com.jasminsp.weatherapp.ui.theme.WeatherAppTheme
 import com.jasminsp.weatherapp.weather.WeatherViewModel
-import kotlinx.coroutines.*
-import java.io.Console
 
 class MainActivity : ComponentActivity(), SensorEventListener {
     companion object {
@@ -44,9 +41,9 @@ class MainActivity : ComponentActivity(), SensorEventListener {
                     color = MaterialTheme.colors.background
                 ) {
                     weatherViewModel.getLocations("Berlin")
-                    Text(tempData.value.toString())
                     //weatherViewModel.getFavouriteWeather(52.52437, 13.41053)
                     Column {
+                        Text("Sensor: ${tempData.value}")
                         ShowFavourites(weatherViewModel)
                         SearchLocations(weatherViewModel)
                     }

--- a/app/src/main/java/com/jasminsp/weatherapp/MainActivity.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/MainActivity.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Card
@@ -14,7 +14,13 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.jasminsp.weatherapp.ui.theme.WeatherAppTheme
 import com.jasminsp.weatherapp.weather.WeatherViewModel
 import kotlinx.coroutines.CoroutineScope
@@ -53,13 +59,32 @@ class MainActivity : ComponentActivity() {
     fun ShowSearchResult(viewModel: WeatherViewModel) {
         val searchResult by viewModel.searchedLocations.observeAsState()
 
-        LazyColumn {
-            searchResult?.results?.forEach {
-                item {
-                    Card(Modifier.clickable {
-                        onSearchResultClick(viewModel, it.latitude, it.longitude)
-                    }) {
-                        it.country?.let { name -> Text(name) }
+        Column(Modifier.fillMaxWidth()) {
+            // Place for search input
+            LazyColumn(Modifier.fillMaxWidth()) {
+                searchResult?.results?.forEach {
+                    item {
+                        Card(
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    onSearchResultClick(viewModel, it.latitude, it.longitude)
+                                }) {
+                            Column(Modifier.padding(all = 20.dp)) {
+                                Row(Modifier.fillMaxWidth().padding(start = 15.dp), Arrangement.SpaceBetween, Alignment.CenterVertically) {
+                                    if (it.admin3 != null) Text(
+                                        it.admin3,
+                                        fontSize = 22.sp
+                                    ) else it.admin2?.let { name -> Text(name, fontSize = 22.sp) }
+                                    Text("Add", Modifier.padding(top = 20.dp), color = Color.Gray)
+                                }
+                                Text(
+                                    "${it.admin1}, ${it.country}",
+                                    Modifier.padding(start = 15.dp),
+                                    fontWeight = FontWeight(400), color = Color.Gray
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/jasminsp/weatherapp/composablesJasmin.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/composablesJasmin.kt
@@ -1,0 +1,84 @@
+package com.jasminsp.weatherapp
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Card
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.jasminsp.weatherapp.weather.WeatherViewModel
+import kotlinx.coroutines.launch
+
+@Composable
+fun ShowFavourites(viewModel: WeatherViewModel) {
+    val favouritesFromDb by viewModel.getFavourites().observeAsState()
+    val favourite by viewModel.favouriteLocations.observeAsState()
+    val scope = rememberCoroutineScope()
+
+    LazyColumn {
+        favouritesFromDb?.forEach {
+            scope.launch {
+                viewModel.getFavouriteWeather(it.latitude, it.longitude)
+            }
+        }
+        item {
+            favourite?.forEach {
+                Text("Temperature is: ${it.current_weather.temperature}")
+            }
+        }
+    }
+}
+
+
+@Composable
+fun SearchLocations(viewModel: WeatherViewModel) {
+    val searchInput by remember { mutableStateOf("berlin") }
+    viewModel.getLocations(searchInput)
+    ShowSearchResult(viewModel)
+}
+
+@Composable
+fun ShowSearchResult(viewModel: WeatherViewModel) {
+    val searchResult by viewModel.searchedLocations.observeAsState()
+
+    Column(Modifier.fillMaxWidth()) {
+        // Place for search input
+        LazyColumn(Modifier.fillMaxWidth()) {
+            searchResult?.results?.forEach {
+                item {
+                    Card(
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                addFavourite(viewModel, it.latitude, it.longitude)
+                            }) {
+                        Column(Modifier.padding(all = 20.dp)) {
+                            Row(
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(start = 15.dp), Arrangement.SpaceBetween, Alignment.CenterVertically) {
+                                if (it.admin3 != null) Text(
+                                    it.admin3,
+                                    fontSize = 22.sp
+                                ) else it.admin2?.let { name -> Text(name, fontSize = 22.sp) }
+                                Text("Add", Modifier.padding(top = 20.dp), color = Color.Gray)
+                            }
+                            Text(
+                                "${it.admin1}, ${it.country}",
+                                Modifier.padding(start = 15.dp),
+                                fontWeight = FontWeight(400), color = Color.Gray
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/jasminsp/weatherapp/database/WeatherDatabase.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/database/WeatherDatabase.kt
@@ -1,9 +1,7 @@
 package com.jasminsp.weatherapp.database
 
 import android.content.Context
-import androidx.room.Database
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room.*
 
 //Creating the database
 @Database(entities = [FavouriteData::class], version = 2, exportSchema = false)

--- a/app/src/main/java/com/jasminsp/weatherapp/database/WeatherDatabaseDao.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/database/WeatherDatabaseDao.kt
@@ -6,7 +6,7 @@ import com.google.gson.internal.bind.util.ISO8601Utils
 import com.jasminsp.weatherapp.web.WeatherApiService
 import java.text.DateFormat
 
-@Entity(tableName = "user_favourites")
+@Entity(tableName = "user_favourites", indices = [Index(value = ["latitude", "longitude"], unique = true)])
 data class FavouriteData(
     @PrimaryKey(autoGenerate = true)
     val locationUid: Long,

--- a/app/src/main/java/com/jasminsp/weatherapp/database/WeatherDatabaseDao.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/database/WeatherDatabaseDao.kt
@@ -2,21 +2,25 @@ package com.jasminsp.weatherapp.database
 
 import androidx.lifecycle.LiveData
 import androidx.room.*
+import com.google.gson.internal.bind.util.ISO8601Utils
+import com.jasminsp.weatherapp.web.WeatherApiService
+import java.text.DateFormat
 
 @Entity(tableName = "user_favourites")
 data class FavouriteData(
     @PrimaryKey(autoGenerate = true)
-    val favouriteUid: Long,
+    val locationUid: Long,
     val latitude: Double,
     val longitude: Double,
 )
+
 
 //Defining functions that can be used with the database
 @Dao
 interface WeatherDatabaseDao {
     //Checking database for conflict, replacing data if any
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertOrUpdate(favouriteData: FavouriteData)
+    suspend fun insertOrUpdate(weatherData: FavouriteData)
 
     // Get all favourites from user_favourites
     @Query("SELECT * FROM user_favourites")

--- a/app/src/main/java/com/jasminsp/weatherapp/repository/LocationRepository.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/repository/LocationRepository.kt
@@ -3,6 +3,7 @@ package com.jasminsp.weatherapp.repository
 import com.jasminsp.weatherapp.web.LocationApiService
 
 class LocationRepository {
+    // Call api service for fetching locations for search
     private val call = LocationApiService.service
     suspend fun getLocations(name: String) = call.getLocationsByName(name)
 }

--- a/app/src/main/java/com/jasminsp/weatherapp/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/repository/WeatherRepository.kt
@@ -4,10 +4,19 @@ import android.app.Application
 import androidx.lifecycle.LiveData
 import com.jasminsp.weatherapp.database.FavouriteData
 import com.jasminsp.weatherapp.database.WeatherDatabase
-import com.jasminsp.weatherapp.web.LocationApiService
 import com.jasminsp.weatherapp.web.WeatherApiService
 
-class WeatherRepository {
+class WeatherRepository(application: Application) {
+    private val weatherDao = WeatherDatabase.get(application.applicationContext).weatherDatabaseDao()
     private val call = WeatherApiService.service
+
+    val favouriteData: LiveData<List<FavouriteData>> = weatherDao.getAllFavourites()
+
+    // Get weather data from api
     suspend fun getWeather(lat: Double, long: Double) = call.getHourlyWeatherWithLocation(lat, long)
+
+    // Add data favourite to database
+    suspend fun addFavourite(lat: Double, long: Double) {
+        weatherDao.insertOrUpdate(FavouriteData(0, lat, long))
+    }
 }

--- a/app/src/main/java/com/jasminsp/weatherapp/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/repository/WeatherRepository.kt
@@ -10,13 +10,16 @@ class WeatherRepository(application: Application) {
     private val weatherDao = WeatherDatabase.get(application.applicationContext).weatherDatabaseDao()
     private val call = WeatherApiService.service
 
-    val favouriteData: LiveData<List<FavouriteData>> = weatherDao.getAllFavourites()
+    fun getFavouriteData(): LiveData<List<FavouriteData>> = weatherDao.getAllFavourites()
 
     // Get weather data from api
     suspend fun getWeather(lat: Double, long: Double) = call.getHourlyWeatherWithLocation(lat, long)
 
     // Add data favourite to database
     suspend fun addFavourite(lat: Double, long: Double) {
+
+
+
         weatherDao.insertOrUpdate(FavouriteData(0, lat, long))
     }
 }

--- a/app/src/main/java/com/jasminsp/weatherapp/utils/Toasts.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/utils/Toasts.kt
@@ -1,0 +1,11 @@
+package com.jasminsp.weatherapp.utils
+
+import android.widget.Toast
+import com.jasminsp.weatherapp.App
+
+    // For showing toast after error occured
+    fun errorToast(error: Error) {
+        Toast.makeText(
+            App.appContext, "$error",
+            Toast.LENGTH_LONG).show()
+    }

--- a/app/src/main/java/com/jasminsp/weatherapp/utils/Units.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/utils/Units.kt
@@ -1,0 +1,6 @@
+package com.jasminsp.weatherapp.utils
+
+data class Units (
+    val timeAndSunriseAndSunset: String = "iso8601",
+    val temperature: String = "°C",
+)

--- a/app/src/main/java/com/jasminsp/weatherapp/weather/WeatherViewModel.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/weather/WeatherViewModel.kt
@@ -3,27 +3,58 @@ package com.jasminsp.weatherapp.weather
 import android.app.Application
 import android.util.Log
 import androidx.lifecycle.*
-import com.jasminsp.weatherapp.database.FavouriteData
 import com.jasminsp.weatherapp.repository.LocationRepository
 import com.jasminsp.weatherapp.repository.WeatherRepository
+import com.jasminsp.weatherapp.utils.errorToast
+import com.jasminsp.weatherapp.web.LocationApiService
+import com.jasminsp.weatherapp.web.WeatherApiService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class WeatherViewModel(application: Application): AndroidViewModel(application) {
     private val locationRepository = LocationRepository()
-    private val weatherRepository = WeatherRepository()
+    private val weatherRepository = WeatherRepository(application)
+    val searchedLocations = MutableLiveData<LocationApiService.Model.Result>()
+    val favouriteLocations = mutableListOf<WeatherApiService.MainWeather>()
 
+
+    // Fetch location from LocationRepository by searched location name
     fun getLocations(name: String) {
         viewModelScope.launch(Dispatchers.IO) {
-            val serverResp = locationRepository.getLocations(name)
-            Log.i("RESPONSE", "$serverResp")
+            try {
+                val serverResp = locationRepository.getLocations(name)
+                Log.i("LOCATION_RESPONSE", "$serverResp")
+
+                // Save data to variable as livedata
+                searchedLocations.postValue(serverResp)
+            } catch (error: Error) {
+                errorToast(error)
+            }
         }
     }
 
+    // Fetch new weather data from weatherRepository by latitude and longitude from api
     fun getFavouriteWeather(lat: Double, long: Double) {
         viewModelScope.launch(Dispatchers.IO) {
-            val serverResp = weatherRepository.getWeather(lat, long)
-            Log.i("RESPONSE", "$serverResp")
+            try {
+                val resp = weatherRepository.getWeather(lat, long)
+                Log.i("WEATHER_RESPONSE", "$resp")
+
+                favouriteLocations.add(resp)
+            } catch (error: Error) {
+                errorToast(error)
+            }
+        }
+    }
+
+    // add favourite longitude and latitude to database
+    fun addFavourite(lat: Double, long: Double) {
+        viewModelScope.launch {
+            try {
+                weatherRepository.addFavourite(lat, long)
+            } catch (error: Error) {
+                errorToast(error)
+            }
         }
     }
 }

--- a/app/src/main/java/com/jasminsp/weatherapp/weather/WeatherViewModel.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/weather/WeatherViewModel.kt
@@ -3,19 +3,26 @@ package com.jasminsp.weatherapp.weather
 import android.app.Application
 import android.util.Log
 import androidx.lifecycle.*
+import com.jasminsp.weatherapp.database.FavouriteData
 import com.jasminsp.weatherapp.repository.LocationRepository
 import com.jasminsp.weatherapp.repository.WeatherRepository
 import com.jasminsp.weatherapp.utils.errorToast
 import com.jasminsp.weatherapp.web.LocationApiService
 import com.jasminsp.weatherapp.web.WeatherApiService
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class WeatherViewModel(application: Application): AndroidViewModel(application) {
     private val locationRepository = LocationRepository()
     private val weatherRepository = WeatherRepository(application)
     val searchedLocations = MutableLiveData<LocationApiService.Model.Result>()
-    val favouriteLocations = mutableListOf<WeatherApiService.MainWeather>()
+    val favouriteLocations = MutableLiveData<MutableSet<WeatherApiService.MainWeather>>()
+    // Used to store favourite data temporarily before sending to favouriteLocations
+    val allFavourites = mutableSetOf<WeatherApiService.MainWeather>()
+
+    // Get favourite data from database saved latitude and longitude
+    fun getFavourites(): LiveData<List<FavouriteData>> = weatherRepository.getFavouriteData()
 
 
     // Fetch location from LocationRepository by searched location name
@@ -40,9 +47,12 @@ class WeatherViewModel(application: Application): AndroidViewModel(application) 
                 val resp = weatherRepository.getWeather(lat, long)
                 Log.i("WEATHER_RESPONSE", "$resp")
 
-                favouriteLocations.add(resp)
+                allFavourites.add(resp)
             } catch (error: Error) {
                 errorToast(error)
+            } finally {
+                delay(2000)
+                favouriteLocations.postValue(allFavourites)
             }
         }
     }
@@ -52,6 +62,8 @@ class WeatherViewModel(application: Application): AndroidViewModel(application) 
         viewModelScope.launch {
             try {
                 weatherRepository.addFavourite(lat, long)
+                delay(1000)
+                getFavouriteWeather(lat, long)
             } catch (error: Error) {
                 errorToast(error)
             }

--- a/app/src/main/java/com/jasminsp/weatherapp/web/LocationApiService.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/web/LocationApiService.kt
@@ -9,10 +9,27 @@ object LocationApiService {
         // API base url
         private const val URL = "https://geocoding-api.open-meteo.com/v1/"
 
+        // data classes to hold the search result
+        object Model {
+            data class  Result (val results: Array<Location>)
+            data class Location (
+                val id: Int,
+                val name: String,
+                val latitude: Double,
+                val longitude: Double,
+                val country_code: String?,
+                val timezone: String?,
+                val country: String?,
+                val admin1: String?,
+                val admin2: String?,
+                val admin3: String?
+            )
+        }
+
         // Get request to endpoint
         interface Service {
             @GET("search?")
-            suspend fun getLocationsByName(@Query("name") action: String)
+            suspend fun getLocationsByName(@Query("name") action: String): Model.Result
         }
 
         // Creating retrofit

--- a/app/src/main/java/com/jasminsp/weatherapp/web/WeatherApiService.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/web/WeatherApiService.kt
@@ -20,8 +20,27 @@ object WeatherApiService {
         val current_weather: BaseCurrentWeather,
         val hourly: BaseHourly,
         val daily: BaseDaily,
-    )
-        data class BaseCurrentWeather (
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as MainWeather
+
+            if (latitude != other.latitude) return false
+            if (longitude != other.longitude) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = latitude.hashCode()
+            result = 31 * result + longitude.hashCode()
+            return result
+        }
+    }
+
+    data class BaseCurrentWeather (
             val temperature: Double,
             val windspeed: Double,
             val weathercode: Byte,

--- a/app/src/main/java/com/jasminsp/weatherapp/web/WeatherApiService.kt
+++ b/app/src/main/java/com/jasminsp/weatherapp/web/WeatherApiService.kt
@@ -1,5 +1,6 @@
 package com.jasminsp.weatherapp.web
 
+import androidx.room.TypeConverter
 import com.jasminsp.weatherapp.database.FavouriteData
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -10,10 +11,40 @@ object WeatherApiService {
     // API base url
     private const val URL = "https://api.open-meteo.com/v1/"
 
+    // Storing weather info into variables before sending to database
+    data class MainWeather (
+        val latitude: Double,
+        val longitude: Double,
+        val timezone: String,
+        val timezone_abbreviation: String,
+        val current_weather: BaseCurrentWeather,
+        val hourly: BaseHourly,
+        val daily: BaseDaily,
+    )
+        data class BaseCurrentWeather (
+            val temperature: Double,
+            val windspeed: Double,
+            val weathercode: Byte,
+            val time: String,
+        )
+        data class BaseHourly (
+            val time: Array<String>,
+            val temperature_2m: Array<Double>,
+        )
+        data class BaseDaily (
+            val time: Array<String>,
+            val temperature_2m_max: Array<Double>,
+            val temperature_2m_min: Array<Double>,
+            val apparent_temperature_max: Array<Double>,
+            val apparent_temperature_min: Array<Double>,
+            val sunrise: Array<String>,
+            val sunset: Array<String>,
+        )
+
     // Get request to endpoint
     interface Service {
-        @GET("forecast?hourly=temperature_2m")
-        suspend fun getHourlyWeatherWithLocation(@Query("latitude") lat: Double, @Query("longitude") long: Double): FavouriteData
+        @GET("forecast?hourly=temperature_2m&daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,sunrise,sunset&current_weather=true&timezone=auto")
+        suspend fun getHourlyWeatherWithLocation(@Query("latitude") lat: Double, @Query("longitude") long: Double): MainWeather
     }
 
     // Creating retrofit


### PR DESCRIPTION
This PR adds the correct way to store data to the database and later fetching the weather data from api.

I have modified the database table a bit. Database has two unique fields, so in database there will always be only 1 row with the same latitude and longitude. This way we can still keep the autogenerated primary key.

Weather data is received from a composable function. Currently there is still a small problem I have not been able to fix. The data updated into the view 1 step later than in to the database. Maybe if any of you have a solution for that, please feel free to fix. Weather data is called for each favourite location in the database and the data is added in to a mutable set of MainWeather data, which is defined in the WeatherRepository. That list is then updated as a bunch in to the favouriteLocations observable. Reason for updating the weather data this way is that .postValue() removes the previous data when called.

In WeatherApiService we define the latitude and longitude of MainWeather as unique keys that define how mutableset sees the duplicates.

Some things that still needs to be added here, on a different branch however, is the limit for favourites.

Let me know if anything.
![Screenshot_1664554838](https://user-images.githubusercontent.com/74709722/193314040-7514cff5-a7e5-4c7d-9306-8d2044b6a274.png)
